### PR TITLE
Unescape HTML for german umlaute

### DIFF
--- a/custom_components/oebb/sensor.py
+++ b/custom_components/oebb/sensor.py
@@ -26,6 +26,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
 )
+import html
 
 CONF_L = "L"
 CONF_EVAID = "evaId"
@@ -193,7 +194,7 @@ class OebbSensor(CoordinatorEntity, SensorEntity):
         else:
             self.attributes = {
                 "startTime": data["journey"][self.idx]["ti"],
-                "lastStop": data["journey"][self.idx]["lastStop"],
+                "lastStop": html.unescape(data["journey"][self.idx]["lastStop"]),
                 "line": data["journey"][self.idx]["pr"],
             }
             now = datetime.now()


### PR DESCRIPTION
- German Umlaute are received html-escaped for `lastStop`; We unescape them to make them readable to the human eye.